### PR TITLE
docker-compose.yml: update invalid image link

### DIFF
--- a/01-sasl-and-tls/docker-compose.yml
+++ b/01-sasl-and-tls/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - redpanda
 
   connect:
-    image: docker.cloudsmith.io/redpanda/connectors/connectors:624ff9e
+    image: docker.redpanda.com/vectorized/connectors
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
connect.image is not found

Fixes: https://github.com/redpanda-data-university/fg-101-field-guide/issues/5

Replace with image mentioned in community Slack `#university` channel [thread](https://redpandacommunity.slack.com/archives/C03JCF2UFGD/p1706041947682969) from Jan 23, 2024.